### PR TITLE
Remove x-cloak attribute from 404 page element

### DIFF
--- a/src/content/404.njk
+++ b/src/content/404.njk
@@ -24,7 +24,7 @@ blankPage: true
     </p>
   </div>
 
-  <div class="lg:col-span-2" x-cloak>
+  <div class="lg:col-span-2">
     {% youTube "_mEC54eTuGw" %}
   </div>
 


### PR DESCRIPTION
This commit removes the x-cloak attribute from a div on the 404 page. This change will affect how content is initially hidden on this page until the associated JavaScript has initialized.