### PR TITLE
Update post metadata and link in single post card

### DIFF
--- a/src/_includes/partials/single-post-card.njk
+++ b/src/_includes/partials/single-post-card.njk
@@ -1,9 +1,9 @@
 <article class="bg-zenith dark:bg-zenith-700/80 p-4 md:p-8 rounded-md">
 	<div class="post-metadata m-0 text-sm">
-		<time datetime="{{ post.data.date | htmlDateString }}">{{ post.data.date | readableDate("LLLL d, yyyy") }}</time>
+		<time datetime="{{ post.date | htmlDateString }}">{{ post.date | readableDate("LLLL d, yyyy") }}</time>
 	</div>
 	<h3 class="text-lg md:text-xl mt-4">
-		<a class="text-current text-pretty inline-block" href="/blog/{{ post.data.title | slugify }}/">{{ post.data.title }}</a>
+		<a class="text-current text-pretty inline-block" href="/blog/{{ post.fileSlug | slugify }}/">{{ post.data.title }}</a>
 	</h3>
 	<p class="text-sm line-clamp-4">{{ post.data.desc }}</p>
 	{%- if post.data.tags|filterTagList|length %}


### PR DESCRIPTION
The commit updated referencing for the post's date and URL slug in the single post card template. The template now uses 'post.date' and 'post.fileSlug' instead of 'post.data.date' and 'post.data.title' respectively. These changes ensure the post card uses up-to-date and accurate metadata for each blog post.